### PR TITLE
修改暗牧逻辑，一定程度上提升了暗牧在25/03狂野环境下的胜率

### DIFF
--- a/card/basic_card.py
+++ b/card/basic_card.py
@@ -170,6 +170,13 @@ class MinionCard(Card):
 
         delta_h += cls.basic_delta_h(state, hand_card_index)
         delta_h += cls.combo_delta_h(state, hand_card_index)
+
+        # 新增逻辑：
+        # 如果对方英雄血量小于等于20且没有嘲讽随从，
+        # 则增加一个 bonus，并将攻击目标设为 -1（即直接攻击对方英雄）
+        if state.oppo_hero.health <= 20 and not state.oppo_has_taunt:
+            args = [-1]  # -1 表示将目标设置为对方英雄
+        
         return (delta_h,) + tuple(args)
 
 

--- a/card/basic_card.py
+++ b/card/basic_card.py
@@ -165,8 +165,11 @@ class MinionNoPoint(MinionCard):
 class MinionPointOppo(MinionCard):
     @classmethod
     def use_with_arg(cls, state, card_index, *args):
+        if len(args) <= 1:
+            logger.warning(f"Receive {len(args)} args in using MinionPointOppo card {state.my_hand_cards[card_index].name}")
+
         gap_index = args[0] if len(args) > 0 else state.my_minion_num
-        oppo_index = args[1] if len(args) > 1 else -1 # 避免出现没有法术直接拍下去的时候的报错 IndexError
+        oppo_index = args[1] if len(args) > 1 else -1
 
 
         click.choose_card(card_index, state.my_hand_card_num)

--- a/card/basic_card.py
+++ b/card/basic_card.py
@@ -138,28 +138,6 @@ class MinionCard(Card):
                 logger.debug(f"{my_hand_card.name} 可以配合 {hand_card.name}")
                 h_sum += 2
 
-        # 新增逻辑：如果剩余法力值充沛（>= 3），并且手牌中存在虚触侍从，
-        # 则优先下虚触侍从：虚触侍从的 combo 值加 bonus，
-        # 而“心灵震爆”、“针灸”、“精神灼烧”的 combo 值减 penalty
-        if state.my_remaining_mana >= 2:
-            # 检查手牌中是否存在虚触侍从
-            has_voidtouched = any(card.card_id == "SW_446" for card in state.my_hand_cards)
-            if has_voidtouched:
-                if hand_card.card_id == "SW_446":
-                    # 计算除了亡者复生的法术数量
-                    num_spells = sum(
-                        1 for card in state.my_hand_cards
-                        if card.cardtype == CARD_SPELL and card.card_id != "RaiseDead"
-                    )
-                    # 虚触侍从的 bonus = 场上随从数量 + 自己手牌中法术数量（不含亡者复生）
-                    h_sum += len(state.my_minions) + num_spells # bonus 数值可调
-                elif hand_card.card_id in ["MindShatter", "Acupuncture", "MindBlast"]:
-                    # 如果当前卡牌是这三个法术中的一个，则降低其 combo 价值
-                    # TODO: 可考虑删去
-                    h_sum -= 2  # penalty 数值可调
-
-        return h_sum
-
         return h_sum
 
     @classmethod
@@ -171,12 +149,6 @@ class MinionCard(Card):
         delta_h += cls.basic_delta_h(state, hand_card_index)
         delta_h += cls.combo_delta_h(state, hand_card_index)
 
-        # 新增逻辑：
-        # 如果对方英雄血量小于等于20且没有嘲讽随从，
-        # 则增加一个 bonus，并将攻击目标设为 -1（即直接攻击对方英雄）
-        if state.oppo_hero.health <= 20 and not state.oppo_has_taunt:
-            args = [-1]  # -1 表示将目标设置为对方英雄
-        
         return (delta_h,) + tuple(args)
 
 
@@ -192,7 +164,7 @@ class MinionNoPoint(MinionCard):
 
 class MinionPointOppo(MinionCard):
     @classmethod
-    def use_with_arg(cls, state, card_index, *args):        
+    def use_with_arg(cls, state, card_index, *args):
         gap_index = args[0] if len(args) > 0 else state.my_minion_num
         oppo_index = args[1] if len(args) > 1 else -1 # 避免出现没有法术直接拍下去的时候的报错 IndexError
 

--- a/card/basic_card.py
+++ b/card/basic_card.py
@@ -138,6 +138,28 @@ class MinionCard(Card):
                 logger.debug(f"{my_hand_card.name} 可以配合 {hand_card.name}")
                 h_sum += 2
 
+        # 新增逻辑：如果剩余法力值充沛（>= 3），并且手牌中存在虚触侍从，
+        # 则优先下虚触侍从：虚触侍从的 combo 值加 bonus，
+        # 而“心灵震爆”、“针灸”、“精神灼烧”的 combo 值减 penalty
+        if state.my_remaining_mana >= 2:
+            # 检查手牌中是否存在虚触侍从
+            has_voidtouched = any(card.card_id == "SW_446" for card in state.my_hand_cards)
+            if has_voidtouched:
+                if hand_card.card_id == "SW_446":
+                    # 计算除了亡者复生的法术数量
+                    num_spells = sum(
+                        1 for card in state.my_hand_cards
+                        if card.cardtype == CARD_SPELL and card.card_id != "RaiseDead"
+                    )
+                    # 虚触侍从的 bonus = 场上随从数量 + 自己手牌中法术数量（不含亡者复生）
+                    h_sum += len(state.my_minions) + num_spells # bonus 数值可调
+                elif hand_card.card_id in ["MindShatter", "Acupuncture", "MindBlast"]:
+                    # 如果当前卡牌是这三个法术中的一个，则降低其 combo 价值
+                    # TODO: 可考虑删去
+                    h_sum -= 2  # penalty 数值可调
+
+        return h_sum
+
         return h_sum
 
     @classmethod

--- a/card/basic_card.py
+++ b/card/basic_card.py
@@ -192,9 +192,10 @@ class MinionNoPoint(MinionCard):
 
 class MinionPointOppo(MinionCard):
     @classmethod
-    def use_with_arg(cls, state, card_index, *args):
-        gap_index = args[0]
-        oppo_index = args[1]
+    def use_with_arg(cls, state, card_index, *args):        
+        gap_index = args[0] if len(args) > 0 else state.my_minion_num
+        oppo_index = args[1] if len(args) > 1 else -1 # 避免出现没有法术直接拍下去的时候的报错 IndexError
+
 
         click.choose_card(card_index, state.my_hand_card_num)
         click.put_minion(gap_index, state.my_minion_num)

--- a/card/detail_card.py
+++ b/card/detail_card.py
@@ -555,6 +555,14 @@ class VoidtouchedAttendant(MinionNoPoint):
     value = 3
     keep_in_hand_bool = True
 
+    @classmethod
+    def utilize_delta_h_and_arg(cls, state: 'StrategyState', hand_card_index: int):
+        num_spells = sum(
+            1 for card in state.my_hand_cards
+            if card.cardtype == CARD_SPELL and card.name != "亡者复生"
+        )
+        return cls.value + num_spells * 0.5 + len(state.my_minions) * 0.5,
+
 
 # 宝藏经销商
 class TreasureMerchant(MinionNoPoint):
@@ -586,8 +594,8 @@ class RaiseDead(SpellNoPoint):
     def best_h_and_arg(cls, state: 'StrategyState', hand_card_index: int):
         if state.my_hero.health <= 3 + state.num_voidtouched_attendant_on_board:  # 用了就死
             return 0,
-        elif any(card.card_id == "DED_513" for card in state.my_hand_cards) and state.my_remaining_mana > 3: #有麻风侏儒先战吼点击
-            return 0
+        elif state.if_card_in_hand("迪菲亚麻风侏儒") and state.my_remaining_mana > 3: #有迪菲亚麻风侏儒先使用他
+            return 0,
         elif state.num_minions_in_my_graveyard >= 2:
             return 100,
         else:
@@ -601,15 +609,9 @@ class ShadowBomber(MinionNoPoint):
 
     @classmethod
     def utilize_delta_h_and_arg(cls, state: 'StrategyState', hand_card_index: int):
-        # 如果剩余法力 >= 2 且手牌中存在虚触侍从（假设其卡牌ID为 "SW_446"），则降低投弹手的价值，
-        # 使得系统优先下虚触侍从
+        # 如果剩余法力 >= 2 且手牌中存在虚触侍从，则降低投弹手的价值，使脚本优先下虚触侍从
         if state.my_remaining_mana >= 2:
-            has_voidtouched = any(
-                card.cardtype == CARD_MINION and card.card_id == "SW_446"
-                for card in state.my_hand_cards
-            )
-            if has_voidtouched:
-                # 返回一个非常低的价值，确保在决策时不选择投弹手
+            if state.if_card_in_hand("虚触侍从"):
                 return -100, 0
 
         # 否则，正常计算投弹手的收益
@@ -657,21 +659,13 @@ class Acupuncture(SpellNoPoint):
         if state.my_hero.health <= damage:
             return -1,
 
-        damage = 4 + state.my_total_spell_power + state.num_voidtouched_attendant_on_board
-        if state.my_hero.health <= damage:
+        # 如果法力充沛，且可以使用英雄技能打脸，那么无论如何也轮不到使用直伤
+        if state.my_remaining_mana >= 2 and not state.my_hero_power.exhausted and state.oppo_hero.can_be_pointed_by_hero_power:
             return -1,
 
-        base_value = state.oppo_hero.delta_h_after_damage(damage) + cls.bias
-        # 如果法力充沛，主动降低针灸的收益（或不加 bonus）
-        if state.my_remaining_mana >= 2:
-            adjustment = -1  # 例如减少1点价值，使其在决策排序中落后于英雄技能
-        else:
-            adjustment = 0
-        bonus = 1 if any(minion.card_id == "SW_446" for minion in state.my_minions) else 0
-        return base_value + adjustment+bonus,
-
-        # 我的血不重要
-        return state.oppo_hero.delta_h_after_damage(damage) + cls.bias,
+        # 虚触侍从可能会被对面解掉，所以要好好利用它，在她活着的时候多打伤害
+        base_value = state.oppo_hero.delta_h_after_damage(damage) + cls.bias + state.num_voidtouched_attendant_on_board
+        return base_value,
 
 
 # 心灵震爆
@@ -682,14 +676,12 @@ class MindShatter(SpellNoPoint):
 
     @classmethod
     def best_h_and_arg(cls, state: 'StrategyState', hand_card_index: int):
-        # 同上，我们使得心灵震爆能够打出combo
-        base_value = state.oppo_hero.delta_h_after_damage(5) + cls.bias
-        if state.my_remaining_mana >= 2:
-            adjustment = -1
-        else:
-            adjustment = 0
-        bonus = 1 if any(minion.card_id == "SW_446" for minion in state.my_minions) else 0
-        return base_value + adjustment + bonus,
+        if state.my_remaining_mana >= 2 and not state.my_hero_power.exhausted and state.oppo_hero.can_be_pointed_by_hero_power:
+            return -1,
+
+        damage = 5 + state.my_total_spell_power + state.num_voidtouched_attendant_on_board
+        base_value = state.oppo_hero.delta_h_after_damage(damage) + cls.bias + state.num_voidtouched_attendant_on_board
+        return base_value,
 
 
 # 暮光欺诈者

--- a/card/hero_power_card.py
+++ b/card/hero_power_card.py
@@ -55,9 +55,9 @@ class MindSpike(HeroPowerCard):
             return 0,
 
         # 如果手牌中有纸艺天使，则直接返回0
-        if any(card.card_id == "TOY_381" for card in state.my_hand_cards):
+        if state.if_card_in_hand("TOY_381"):
             return 0,
-            
+
         best_index = -1
         best_delta_h = state.oppo_hero.delta_h_after_damage(2)
 
@@ -73,24 +73,6 @@ class MindSpike(HeroPowerCard):
         # 二费打二不赚
         if state.my_hero_power.current_cost >= 2:
             best_delta_h /= state.my_hero_power.current_cost
-
-        # 统计手牌中可用的随从数量
-        available_minion_count = sum(
-            1 for card in state.my_hand_cards
-            if card.cardtype == CARD_MINION and card.current_cost <= state.my_remaining_mana and card.card_id != "YOD_032"
-        )
-
-        # 如果剩余法力 >= 2 且手牌中没有可用随从，则增加 bonus
-        if state.my_remaining_mana >= 2 and available_minion_count == 0:
-            bonus = 5  # 此数值可根据实际调优需要修改
-        else:
-            bonus = 0
-
-        # 如果敌方英雄的生命值低于15，则增加 bonus，默认敌方英雄
-        if state.oppo_hero.health < 15:
-            bonus = 5  # 此数值可根据实际调优需要修改
-            return best_delta_h + bonus, -1
-
 
         return best_delta_h, best_index
 

--- a/card/hero_power_card.py
+++ b/card/hero_power_card.py
@@ -54,6 +54,10 @@ class MindSpike(HeroPowerCard):
         if state.my_hero_power.exhausted:
             return 0,
 
+        # 如果手牌中有纸艺天使，则直接返回0
+        if any(card.card_id == "TOY_381" for card in state.my_hand_cards):
+            return 0,
+            
         best_index = -1
         best_delta_h = state.oppo_hero.delta_h_after_damage(2)
 
@@ -69,6 +73,24 @@ class MindSpike(HeroPowerCard):
         # 二费打二不赚
         if state.my_hero_power.current_cost >= 2:
             best_delta_h /= state.my_hero_power.current_cost
+
+        # 统计手牌中可用的随从数量
+        available_minion_count = sum(
+            1 for card in state.my_hand_cards
+            if card.cardtype == CARD_MINION and card.current_cost <= state.my_remaining_mana and card.card_id != "YOD_032"
+        )
+
+        # 如果剩余法力 >= 2 且手牌中没有可用随从，则增加 bonus
+        if state.my_remaining_mana >= 2 and available_minion_count == 0:
+            bonus = 5  # 此数值可根据实际调优需要修改
+        else:
+            bonus = 0
+
+        # 如果敌方英雄的生命值低于15，则增加 bonus，默认敌方英雄
+        if state.oppo_hero.health < 15:
+            bonus = 5  # 此数值可根据实际调优需要修改
+            return best_delta_h + bonus, -1
+
 
         return best_delta_h, best_index
 

--- a/card/id2card.py
+++ b/card/id2card.py
@@ -81,4 +81,5 @@ ID2CARD_DICT = {
     "CORE_SW_448": DarkbishopBenedictus,
     "SW_448": DarkbishopBenedictus,
     "DED_513": DefiasCleaner,
+    "YOD_032": FrenziedFelwing,
 }

--- a/strategy.py
+++ b/strategy.py
@@ -190,11 +190,9 @@ class StrategyState:
     def oppo_minion_num(self):
         return len(self.oppo_minions)
 
-    @property
     def num_card_in_hand(self, name_or_id):
         return sum(1 for hand_card in self.my_hand_cards if hand_card.name == name_or_id or hand_card.card_id == name_or_id)
 
-    @property
     def if_card_in_hand(self, name_or_id):
         return any(hand_card.name == name_or_id or hand_card.card_id == name_or_id for hand_card in self.my_hand_cards)
 

--- a/strategy.py
+++ b/strategy.py
@@ -191,6 +191,14 @@ class StrategyState:
         return len(self.oppo_minions)
 
     @property
+    def num_card_in_hand(self, name_or_id):
+        return sum(1 for hand_card in self.my_hand_cards if hand_card.name == name_or_id or hand_card.card_id == name_or_id)
+
+    @property
+    def if_card_in_hand(self, name_or_id):
+        return any(hand_card.name == name_or_id or hand_card.card_id == name_or_id for hand_card in self.my_hand_cards)
+
+    @property
     def my_minion_num(self):
         return len(self.my_minions)
 

--- a/strategy.py
+++ b/strategy.py
@@ -498,6 +498,7 @@ class StrategyState:
             else:
                 res = detail_card.best_h_and_arg(self, hand_card_index) 
                 if not isinstance(res, tuple): #解决如果战吼随从没有对方可点击的随从的问题
+                    logger.warning(f"卡牌-[{hand_card_index}]({hand_card.name}) best_h_and_arg返回值格式错误: {res}")
                     res = (res,)
                 delta_h, *args = res
 

--- a/strategy.py
+++ b/strategy.py
@@ -488,7 +488,11 @@ class StrategyState:
                 else:
                     logger.debug(f"卡牌-[{hand_card_index}]({hand_card.name})无法评判")
             else:
-                delta_h, *args = detail_card.best_h_and_arg(self, hand_card_index)
+                res = detail_card.best_h_and_arg(self, hand_card_index) 
+                if not isinstance(res, tuple): #解决如果战吼随从没有对方可点击的随从的问题
+                    res = (res,)
+                delta_h, *args = res
+
                 logger.debug(f"卡牌-[{hand_card_index}]({hand_card.name}) "
                             f"delta_h: {delta_h}, *args: {args} (手写行为)")
 

--- a/strategy_entity.py
+++ b/strategy_entity.py
@@ -32,7 +32,7 @@ class StrategyEntity:
 
     @property
     def is_pirate(self):
-        return "PIRATE" in self.races
+        return "PIRATE" in self.races or "ALL" in self.races
 
     @property
     def is_shadow_spell(self):


### PR DESCRIPTION
详见commit，
补充一点，修改逻辑是，30血暗牧强调打脸，一定是**降低敌方英雄血量**>>**解场随从**（*至少到目前的版本为止*）；
因此，我对于**随从攻击**、**mindspike**英雄技能、有了斩杀线/一定血量以下的切换，降低*随从交互*，提升*攻击换血效率*；
其次是，进一步强化虚触侍从的对于所有卡牌的重要性，添加了更多的能够连击的combo：迪菲亚麻风侏儒+亡者复生；anything+虚触侍从；
最后是修正了一些trivial bug。

未来潜在工作，也许进一步微调对于随从的价值函数的计算，使得所有的攻击矢量起点和终点更加合理；调整在更加模糊的存在争议的下随从以及攻击上的特殊处理。

个人在修改完全版本后，从钻石5几乎连胜到钻石1两颗星，手动渡劫。总体微调测试加自己手动挡综合月度胜率53%；readme中的暗牧卡组对战战士术士大劣，其余大优。